### PR TITLE
Secure GitHub CI workflows to repository owner only

### DIFF
--- a/.github/workflows/cleanup-branch-preview.yml
+++ b/.github/workflows/cleanup-branch-preview.yml
@@ -5,14 +5,28 @@ on:
   pull_request:
     types: [closed]
 
+# Default permissions - read only
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    # Only grant write permissions to repository owner
+    permissions:
+      contents: write
     if: github.event_name == 'delete' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
+      - name: Validate actor is repository owner
+        run: |
+          REPO_OWNER="${{ github.repository_owner }}"
+          ACTOR="${{ github.actor }}"
+          if [ "$ACTOR" != "$REPO_OWNER" ]; then
+            echo "ERROR: Only the repository owner ($REPO_OWNER) can trigger cleanup operations."
+            echo "Current actor: $ACTOR"
+            exit 1
+          fi
+          echo "Actor validation passed: $ACTOR"
       - name: Determine branch name
         id: branch
         run: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,14 +3,13 @@ name: deploy-branch-version
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
+# Default permissions - read only
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
+
+# Separate permission blocks for each job to minimize exposure
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && 'pages' || format('pages-{0}', github.ref) }}
@@ -19,6 +18,11 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # Only grant elevated permissions to repository owner
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     env:
       CI: true
       VITEST: true
@@ -26,6 +30,16 @@ jobs:
       matrix:
         bun-version: [latest]
     steps:
+      - name: Validate actor is repository owner
+        run: |
+          REPO_OWNER="${{ github.repository_owner }}"
+          ACTOR="${{ github.actor }}"
+          if [ "$ACTOR" != "$REPO_OWNER" ]; then
+            echo "ERROR: Only the repository owner ($REPO_OWNER) can trigger deployments."
+            echo "Current actor: $ACTOR"
+            exit 1
+          fi
+          echo "Actor validation passed: $ACTOR"
       - uses: actions/checkout@v4
       - name: Setup Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
@@ -70,65 +84,3 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4
-
-      - name: Deploy branch preview
-        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
-        run: |
-          # Configure git
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Clone gh-pages branch
-          git clone --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages-deploy
-          cd gh-pages-deploy
-
-          # Create branches directory if it doesn't exist
-          mkdir -p branches
-
-          # Remove old branch deployment if it exists
-          rm -rf "branches/${{ github.ref_name }}"
-
-          # Copy new build
-          mkdir -p "branches/${{ github.ref_name }}"
-          cp -r ../dist/* "branches/${{ github.ref_name }}/"
-
-          # Create/update index for branches (optional - lists all branch deployments)
-          cat > branches/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>Branch Previews</title>
-            <style>
-              body { font-family: system-ui; max-width: 800px; margin: 50px auto; padding: 20px; }
-              h1 { color: #333; }
-              ul { list-style: none; padding: 0; }
-              li { margin: 10px 0; }
-              a { color: #0066cc; text-decoration: none; }
-              a:hover { text-decoration: underline; }
-            </style>
-          </head>
-          <body>
-            <h1>Branch Preview Deployments</h1>
-            <ul id="branches"></ul>
-            <script>
-              fetch('https://api.github.com/repos/${{ github.repository }}/branches')
-                .then(r => r.json())
-                .then(branches => {
-                  const list = document.getElementById('branches');
-                  branches
-                    .filter(b => b.name !== 'main' && b.name !== 'gh-pages')
-                    .forEach(b => {
-                      const li = document.createElement('li');
-                      li.innerHTML = '<a href="' + b.name + '/">' + b.name + '</a>';
-                      list.appendChild(li);
-                    });
-                });
-            </script>
-          </body>
-          </html>
-          EOF
-
-          # Commit and push
-          git add .
-          git commit -m "Deploy branch preview: ${{ github.ref_name }}" || echo "No changes to commit"
-          git push


### PR DESCRIPTION
Security improvements:
- Remove pull_request trigger from deployment workflow to prevent PR-based attacks
- Add actor validation to ensure only repository owner can trigger deployments
- Remove branch preview deployments that allowed arbitrary branch publishing
- Set default permissions to read-only, grant write only at job level
- Add owner validation to cleanup workflow

These changes ensure only the repository owner can make or merge changes that trigger deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)