### PR TITLE
Fix broken CORS proxies and restore retry summary button

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -17,6 +17,7 @@ interface StoryCardProps {
   onToggleComments: (storyId: number) => void;
   onHideArticle: (storyId: number) => void;
   onShowArticle: (storyId: number) => void;
+  onRetrySummary?: (storyId: number) => void;
   isHidden: boolean;
   showingHidden: boolean;
 }
@@ -54,6 +55,7 @@ export const StoryCard = React.memo<StoryCardProps>(({
   onToggleComments,
   onHideArticle,
   onShowArticle,
+  onRetrySummary,
   isHidden,
   showingHidden
 }) => {
@@ -270,6 +272,15 @@ export const StoryCard = React.memo<StoryCardProps>(({
                   ) : summaryFailed ? (
                     <div className="failed-summary">
                       <em>Summary unavailable</em>
+                      {onRetrySummary && (
+                        <button
+                          className="retry-summary-btn"
+                          onClick={() => onRetrySummary(story.id)}
+                          title="Retry loading summary"
+                        >
+                          ↻ Retry
+                        </button>
+                      )}
                     </div>
                   ) : null}
                 </div>

--- a/src/components/StoryList.tsx
+++ b/src/components/StoryList.tsx
@@ -161,6 +161,18 @@ export const StoryList = React.memo<StoryListProps>(({ category = 'top', viewMod
     actionsRef.current.toggleStoryExpansion(storyId);
   }, []); // No dependencies - use ref
 
+  const retrySummary = useCallback((storyId: number) => {
+    console.debug(`[Summary] Retry requested for story ${storyId}`);
+    const story = visibleStories.find(s => s.id === storyId);
+    if (!story) {
+      console.warn(`[Summary] Story ${storyId} not found for retry`);
+      return;
+    }
+    // Clear failed state before retrying
+    actionsRef.current.clearSummaryFailed(storyId);
+    loadSummary(story);
+  }, [visibleStories, loadSummary]);
+
   // Pre-load comments for the first few visible stories in the background
   useEffect(() => {
     if (loading || !visibleStories.length) {
@@ -248,6 +260,7 @@ export const StoryList = React.memo<StoryListProps>(({ category = 'top', viewMod
               onToggleComments={toggleComments}
               onHideArticle={hideArticle}
               onShowArticle={showArticle}
+              onRetrySummary={retrySummary}
               isHidden={isArticleHidden(story.id)}
               showingHidden={showHiddenArticles}
             />

--- a/src/services/hackerNewsApi.ts
+++ b/src/services/hackerNewsApi.ts
@@ -66,15 +66,41 @@ class HackerNewsApi {
 
   private async fetchHtmlContent(url: string): Promise<string | null> {
     const proxies = [
+      // Primary: allorigins.win (most reliable currently)
+      {
+        url: `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
+        extractContent: (response: { data: { contents: string } }) => response.data.contents,
+        name: 'allorigins.win'
+      },
+      // Fallback 1: api.cors.lol
       {
         url: `https://api.cors.lol/?url=${encodeURIComponent(url)}`,
         extractContent: (response: { data: string }) => response.data,
         name: 'api.cors.lol'
       },
+      // Fallback 2: corsproxy.io
       {
-        url: `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
-        extractContent: (response: { data: { contents: string } }) => response.data.contents,
-        name: 'allorigins.win'
+        url: `https://corsproxy.io/?${encodeURIComponent(url)}`,
+        extractContent: (response: { data: string }) => response.data,
+        name: 'corsproxy.io'
+      },
+      // Fallback 3: codetabs.com
+      {
+        url: `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}`,
+        extractContent: (response: { data: string }) => response.data,
+        name: 'codetabs.com'
+      },
+      // Fallback 4: thingproxy
+      {
+        url: `https://thingproxy.freeboard.io/fetch/${encodeURIComponent(url)}`,
+        extractContent: (response: { data: string }) => response.data,
+        name: 'thingproxy'
+      },
+      // Fallback 5: cors.sh
+      {
+        url: `https://cors.sh/${url}`,
+        extractContent: (response: { data: string }) => response.data,
+        name: 'cors.sh'
       }
     ];
 

--- a/src/styles/toodles.css
+++ b/src/styles/toodles.css
@@ -1319,6 +1319,28 @@ body {
   margin-right: 4px;
 }
 
+/* Retry Summary Button */
+.retry-summary-btn {
+  background: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: 9px;
+  cursor: pointer;
+  margin-left: 6px;
+  transition: background-color 0.2s ease;
+  font-weight: 500;
+}
+
+.retry-summary-btn:hover {
+  background: #45a049;
+}
+
+.retry-summary-btn:active {
+  transform: translateY(1px);
+}
+
 /* Load More Section */
 .load-more-section {
   text-align: center;


### PR DESCRIPTION
This change addresses the broken summaries that were introduced in recent PRs. It correctly falls back to a robust proxy list (now correctly prioritized for `allorigins.win`) and restores the "Retry" button on the UI if a fetch fails.

---
*PR created automatically by Jules for task [14501572408281980895](https://jules.google.com/task/14501572408281980895) started by @jsoros*