### PR TITLE
🔒 Fix XSS via HTML Sanitization Bypass in StoryCard

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -45,6 +45,19 @@ const formatTimeAgo = (timestamp: number): string => {
   return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
 };
 
+// Configure DOMPurify to add target="_blank" and rel="noopener noreferrer" to all links
+const sanitizeConfig = {
+  ADD_ATTR: ['target'],
+  ALLOWED_TAGS: ['a', 'p', 'i', 'code', 'pre', 'br'],
+  ALLOWED_ATTR: ['href', 'target', 'rel']
+};
+
+const sanitizeStoryText = (text: string): string => {
+  const clean = DOMPurify.sanitize(text, sanitizeConfig);
+  // Add target="_blank" and rel="noopener noreferrer" to all links
+  return clean.replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ');
+};
+
 export const StoryCard = React.memo<StoryCardProps>(({
   story,
   viewMode,
@@ -256,7 +269,7 @@ export const StoryCard = React.memo<StoryCardProps>(({
               {story.text && (
                 <div 
                   className="story-summary" 
-                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(story.text) }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeStoryText(story.text) }}
                 />
               )}
 

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -7,13 +7,7 @@ const mockOnToggleComments = vi.fn();
 const mockOnHideArticle = vi.fn();
 const mockOnShowArticle = vi.fn();
 
-// Mock DOMPurify
-vi.mock('dompurify', () => ({
-  default: {
-    sanitize: vi.fn((html: string) => html),
-  },
-}));
-
+// Use actual DOMPurify to test sanitization
 // Mock date-fns
 vi.mock('date-fns', () => ({
   formatDistanceToNow: vi.fn(() => '2 hours ago'),
@@ -66,5 +60,49 @@ describe('StoryCard', () => {
     expect(screen.getByText(/Test Story Title/)).toBeInTheDocument();
     expect(screen.getByText('100 points')).toBeInTheDocument();
     expect(screen.getByText('25 comments')).toBeInTheDocument();
+  });
+
+  describe('HTML Sanitization', () => {
+    it('sanitizes dangerous HTML payloads', () => {
+      const maliciousStory = {
+        ...mockStory,
+        text: 'Hello <script>alert("xss")</script><img src="x" onerror="alert(1)">World',
+      };
+
+      const { container } = render(
+        <StoryCard {...defaultProps} story={maliciousStory} viewMode="full" />
+      );
+
+      const summaryElement = container.querySelector('.story-summary');
+      expect(summaryElement).not.toBeNull();
+      // Should strip script and img tags but keep text
+      expect(summaryElement?.innerHTML).toBe('Hello World');
+    });
+
+    it('allows permitted tags and adds target/rel to links', () => {
+      const safeStory = {
+        ...mockStory,
+        text: 'Check this <a href="https://example.com">link</a> and <code>code</code><br><p>paragraph</p>',
+      };
+
+      const { container } = render(
+        <StoryCard {...defaultProps} story={safeStory} viewMode="full" />
+      );
+
+      const summaryElement = container.querySelector('.story-summary');
+      expect(summaryElement).not.toBeNull();
+
+      // Should preserve a, code, br, p tags
+      expect(summaryElement?.querySelector('code')).toBeInTheDocument();
+      expect(summaryElement?.querySelector('br')).toBeInTheDocument();
+      expect(summaryElement?.querySelector('p')).toBeInTheDocument();
+
+      // Link should have added attributes
+      const link = summaryElement?.querySelector('a');
+      expect(link).toBeInTheDocument();
+      expect(link?.getAttribute('href')).toBe('https://example.com');
+      expect(link?.getAttribute('target')).toBe('_blank');
+      expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a Cross-Site Scripting (XSS) via HTML Sanitization Bypass vulnerability in `src/components/StoryCard.tsx`. `dangerouslySetInnerHTML` was being called with `DOMPurify.sanitize(story.text)` without a strict configuration, which could allow potentially malicious HTML (such as `<img>` or `<math>` tags) to be executed via mutation XSS.

⚠️ **Risk:** The potential impact if left unfixed
Hacker News data is fundamentally untrusted user input. Without a strict configuration, malicious actors could craft specific HN stories that, when rendered, execute arbitrary JavaScript in the context of the user's browser, leading to session hijacking, data theft, or actions being performed on behalf of the user.

🛡️ **Solution:** How the fix addresses the vulnerability
Configured `DOMPurify` with an explicit, strict allowlist. Only non-executable markup (`a`, `p`, `i`, `code`, `pre`, `br`) is allowed. Furthermore, enforced `target="_blank"` and `rel="noopener noreferrer"` attributes on all anchor links to protect against reverse tabnabbing and align the behavior with the rest of the application. Added test cases to ensure that XSS vectors like `<script>` or `<img>` with `onerror` payloads are fully stripped and safe elements are preserved.

---
*PR created automatically by Jules for task [12432500621226537919](https://jules.google.com/task/12432500621226537919) started by @jsoros*