### PR TITLE
🔒 Fix false positive security warning on internal skip links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ function App() {
   return (
     <div>
       {/* Skip links for keyboard navigation */}
+      {/* Security: These are internal in-page anchor links for accessibility, not external links. They do not require target="_blank" or rel="noopener noreferrer". */}
       <a href="#main-content" className="skip-link" onClick={(e) => {
         e.preventDefault();
         skipToContent();


### PR DESCRIPTION
🎯 **What:** A security vulnerability scanner incorrectly flagged missing `rel="noopener noreferrer"` attributes on internal accessibility skip links.
⚠️ **Risk:** None, as these are internal anchor links (`href="#main-content"`). It is a false positive.
🛡️ **Solution:** Added a JSX comment directly above the skip links clearly explaining that they are internal navigation aids and do not require external link security attributes. This should help prevent future misidentifications by scanners or developers.

---
*PR created automatically by Jules for task [13353930090077234618](https://jules.google.com/task/13353930090077234618) started by @jsoros*