### PR TITLE
🔒 Fix DOM Clobbering/XSS vulnerability in StoryCard text sanitization

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -46,7 +46,7 @@ const formatTimeAgo = (timestamp: number): string => {
   return formatDistanceToNow(new Date(timestamp * 1000), { addSuffix: true });
 };
 
-// Configure DOMPurify to add target="_blank" and rel="noopener noreferrer" to all links
+// Configure DOMPurify to allow needed tags and attributes
 const sanitizeConfig = {
   ADD_ATTR: ['target'],
   ALLOWED_TAGS: ['a', 'p', 'i', 'code', 'pre', 'br'],
@@ -54,9 +54,19 @@ const sanitizeConfig = {
 };
 
 const sanitizeStoryText = (text: string): string => {
+  // Safely add target="_blank" and rel="noopener noreferrer" using a DOMPurify hook
+  // We add and remove the hook so this behavior is scoped only to this function call
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName && node.tagName.toLowerCase() === 'a') {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
   const clean = DOMPurify.sanitize(text, sanitizeConfig);
-  // Add target="_blank" and rel="noopener noreferrer" to all links
-  return clean.replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ');
+
+  DOMPurify.removeHook('afterSanitizeAttributes');
+  return clean;
 };
 
 export const StoryCard = React.memo<StoryCardProps>(({

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -72,6 +72,8 @@ describe('StoryCard', () => {
     // In title view, the link wraps the title
     const link = screen.getByRole('link', { name: 'Test Story Title' });
     expect(link).toHaveAttribute('href', 'about:blank');
+  });
+
   describe('HTML Sanitization', () => {
     it('sanitizes dangerous HTML payloads', () => {
       const maliciousStory = {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `StoryCard.tsx` component used an insecure `.replace()` regex on the output of `DOMPurify.sanitize()` to add `target="_blank"` and `rel="noopener noreferrer"`. Doing string manipulation on the output of a sanitizer effectively defeats the purpose of the sanitizer and introduces XSS and DOM Clobbering vulnerabilities because the modified string is never re-sanitized.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could craft a specific payload that survives the initial `DOMPurify` pass, but when modified by the regex replacement, forms a new, malicious HTML structure (e.g., mXSS or DOM Clobbering). This could allow the attacker to execute arbitrary JavaScript in the context of the user's browser, leading to session hijacking, data theft, or unauthorized actions.

🛡️ **Solution:** How the fix addresses the vulnerability
The dangerous regex replacement was removed. Instead, the component now utilizes `DOMPurify`'s built-in hooks, specifically `afterSanitizeAttributes`, to securely add the necessary attributes (`target="_blank"` and `rel="noopener noreferrer"`) during the sanitization process itself. The hook is carefully scoped by adding and removing it around the `DOMPurify.sanitize()` call to prevent it from affecting other parts of the application (like `Comments.tsx`) that might rely on different sanitization rules or hooks.

---
*PR created automatically by Jules for task [12127782215710227056](https://jules.google.com/task/12127782215710227056) started by @jsoros*