### PR TITLE
🔒 Fix URL Sanitization bypass vulnerability in sanitizeUrl

### DIFF
--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -72,6 +72,8 @@ describe('StoryCard', () => {
     // In title view, the link wraps the title
     const link = screen.getByRole('link', { name: 'Test Story Title' });
     expect(link).toHaveAttribute('href', 'about:blank');
+  });
+
   describe('HTML Sanitization', () => {
     it('sanitizes dangerous HTML payloads', () => {
       const maliciousStory = {

--- a/src/utils/__tests__/security.test.ts
+++ b/src/utils/__tests__/security.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeUrl } from '../security';
+
+describe('sanitizeUrl', () => {
+  it('allows valid http/https URLs', () => {
+    expect(sanitizeUrl('http://example.com')).toBe('http://example.com');
+    expect(sanitizeUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  it('allows relative URLs', () => {
+    expect(sanitizeUrl('/path/to/page')).toBe('/path/to/page');
+    expect(sanitizeUrl('path/to/page')).toBe('path/to/page');
+    expect(sanitizeUrl('?query=string')).toBe('?query=string');
+  });
+
+  it('blocks standard malicious protocols', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('vbscript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank');
+  });
+
+  it('blocks malicious protocols with mixed case', () => {
+    expect(sanitizeUrl('JavaScript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('VbScRiPt:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks malicious protocols with leading whitespace', () => {
+    expect(sanitizeUrl(' javascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('\tjavascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('\njavascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('\rjavascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('blocks malicious protocols with control characters (bypass test)', () => {
+    expect(sanitizeUrl('\x01javascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('\x1Ajavascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('\x00javascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('j\navascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('j\tavascript:alert(1)')).toBe('about:blank');
+    expect(sanitizeUrl('j\ravascript:alert(1)')).toBe('about:blank');
+  });
+
+  it('handles undefined or empty URLs', () => {
+    expect(sanitizeUrl(undefined)).toBeUndefined();
+    expect(sanitizeUrl('')).toBe('');
+  });
+});

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -15,8 +15,10 @@ export const sanitizeUrl = (url: string | undefined): string | undefined => {
     return url;
   } catch {
     // If parsing fails, fall back to safe check
-    const lowerUrl = url.trim().toLowerCase();
-    if (lowerUrl.startsWith('javascript:') || lowerUrl.startsWith('vbscript:') || lowerUrl.startsWith('data:')) {
+    // Remove all whitespace and control characters before checking
+    // eslint-disable-next-line no-control-regex
+    const normalizedUrl = url.replace(/[\s\x00-\x1F\x7F-\x9F]/g, '').toLowerCase();
+    if (normalizedUrl.startsWith('javascript:') || normalizedUrl.startsWith('vbscript:') || normalizedUrl.startsWith('data:')) {
       return 'about:blank';
     }
     return url;


### PR DESCRIPTION
🎯 **What:** The `sanitizeUrl` fallback check in `src/utils/security.ts` was vulnerable to protocol obfuscation, allowing execution of arbitrary code via specifically crafted strings (like `\x01javascript:alert(1)` or `j\navascript:`).
⚠️ **Risk:** An attacker could craft a malicious Hacker News story URL containing an XSS payload that would bypass the existing `.trim()` and `.startsWith()` checks. This could lead to account takeover or the execution of arbitrary actions on behalf of the user when clicking a crafted link.
🛡️ **Solution:** Updated the fallback mechanism to forcefully strip all whitespace (`\s`) and control characters (`\x00-\x1F`, `\x7F-\x9F`) from the string before performing the `startsWith` validation. Added comprehensive unit tests targeting various obfuscation methods to verify the safety logic.

---
*PR created automatically by Jules for task [1502049567797683230](https://jules.google.com/task/1502049567797683230) started by @jsoros*